### PR TITLE
Don't use exact versions of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": ">=5.3.3",
-    "gitonomy/gitlib": "0.1.7",
-    "symfony/console": "2.6.7"
+    "gitonomy/gitlib": "~0.1",
+    "symfony/console": "~2.5"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.5"


### PR DESCRIPTION
I was facing issues because laravel 4.2 requires `2.5.*` which could never be satisfied with `2.6.7`.