### PR TITLE
Add support for phar 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_script:
 # In case of timeouts and build failures you may want to prepend 'travis_retry' to the following commands:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install -n
+  - wget -O box.phar https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar
 
 # Explicitly use the phpunit from composer, not any system-wide found
 script: 
@@ -17,3 +18,15 @@ script:
 
 after_success:
   - php vendor/bin/codacycoverage clover build/coverage/xml
+
+before_deploy:
+  - php -d phar.readonly=0 box.phar build && chmod +x build/codacy-coverage.phar
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: <api-key>
+  file: build/codacy-coverage.phar
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_script:
 # In case of timeouts and build failures you may want to prepend 'travis_retry' to the following commands:
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install -n
-  - wget -O box.phar https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar
 
 # Explicitly use the phpunit from composer, not any system-wide found
 script: 
@@ -18,15 +17,3 @@ script:
 
 after_success:
   - php vendor/bin/codacycoverage clover build/coverage/xml
-
-before_deploy:
-  - php -d phar.readonly=0 box.phar build && chmod +x build/codacy-coverage.phar
-
-deploy:
-  provider: releases
-  skip_cleanup: true
-  api_key:
-    secure: <api-key>
-  file: build/codacy-coverage.phar
-  on:
-    tags: true

--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@
 
 # Installation
 
-Setup codacy-coverage as phar, you can simply download a pre-compiled and ready-to-use version as a phar to any directory. Simply download the latest `codacy-coverage.phar` file from our [releases page](https://github.com/codacy/php-codacy-coverage/releases):
-
-[Latest release](https://github.com/codacy/php-codacy-coverage/releases/latest)
-
-That's it already.
-
 Setup codacy-coverage with Composer, just add the following to your composer.json:
 
 ```js
@@ -54,6 +48,12 @@ We have php5-curl dependency, if you have issues related to curl_init() please i
 ```
 sudo apt-get install php5-curl
 ```
+
+Setup codacy-coverage as phar, you can simply download a pre-compiled and ready-to-use version as a phar to any directory. Simply download the latest `codacy-coverage.phar` file from our [releases page](https://github.com/codacy/php-codacy-coverage/releases):
+
+[Latest release](https://github.com/codacy/php-codacy-coverage/releases/latest)
+
+That's it already.
 
 ## Updating Codacy
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@
 
 # Installation
 
+Setup codacy-coverage as phar, you can simply download a pre-compiled and ready-to-use version as a phar to any directory. Simply download the latest `codacy-coverage.phar` file from our [releases page](https://github.com/codacy/php-codacy-coverage/releases):
+
+[Latest release](https://github.com/codacy/php-codacy-coverage/releases/latest)
+
+That's it already.
+
 Setup codacy-coverage with Composer, just add the following to your composer.json:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ We have php5-curl dependency, if you have issues related to curl_init() please i
 sudo apt-get install php5-curl
 ```
 
+## Alternative Installation (using phar)
+
 Setup codacy-coverage as phar, you can simply download a pre-compiled and ready-to-use version as a phar to any directory. Simply download the latest `codacy-coverage.phar` file from our [releases page](https://github.com/codacy/php-codacy-coverage/releases):
 
 [Latest release](https://github.com/codacy/php-codacy-coverage/releases/latest)

--- a/box.json
+++ b/box.json
@@ -1,0 +1,9 @@
+{
+    "directories": [
+        "src",
+        "vendor"
+    ],
+    "main": "bin/codacycoverage",
+    "output": "build/codacy-coverage.phar",
+    "stub": true
+}

--- a/circle.yml
+++ b/circle.yml
@@ -6,8 +6,18 @@ dependencies:
   pre:
     - curl -s http://getcomposer.org/installer | php
     - php composer.phar install -n
+    - go get github.com/aktau/github-release
+    - wget -O box.phar https://github.com/box-project/box2/releases/download/2.7.5/box-2.7.5.phar
 
 test:
   post:
     - php vendor/bin/phpunit --coverage-clover build/coverage/xml tests
     - php bin/codacycoverage clover build/coverage/xml
+
+deployment:
+  release:
+    tag: /[0-9]+(\.[0-9]+)*/
+    commands:
+      - php -d phar.readonly=0 box.phar build
+      - git config user.name $CIRCLE_PROJECT_USERNAME
+      - github-release upload --user $CIRCLE_PROJECT_USERNAME --repo $CIRCLE_PROJECT_REPONAME --tag $CIRCLE_TAG --name codacy-coverage.phar --file build/codacy-coverage.phar


### PR DESCRIPTION
This patch will add support for creating an **phar** for each new release.

The intention behind this pull request is to be able to use an **phar** instead of the **composer dependency** to fulfill the task of uploading the generated coverage report.

Things that need to be done:
- [x] To be able to add the created **phar** during the travis build to the release, an **github api access token** has to be added to the **travis.yml**. Please provide me an **encrypted github access token** so i can update this pull request.

See https://docs.travis-ci.com/user/deployment/releases/ and https://docs.travis-ci.com/user/environment-variables/#Defining-encrypted-variables-in-.travis.yml for further details.

Please let me know if i could provide any further details.