### PR TITLE
Fix Console compatibility with Symfony 5

### DIFF
--- a/src/Codacy/Coverage/Command/Clover.php
+++ b/src/Codacy/Coverage/Command/Clover.php
@@ -70,6 +70,8 @@ class Clover extends ConsoleCommand
         if ($output->isVerbose()) {
             $output->writeln($result);
         }
+        
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Execute must return an integer since Symfony Console 5